### PR TITLE
fix installation from pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,10 @@ from distutils.core import setup
 
 setup(
     name='firebase-token-generator',
-    version='1.2',
+    version='1.3',
     author='Greg Soltis',
     author_email='greg@firebase.com',
+    zip_safe=False,
     py_modules=['firebase_token_generator'],
     license='LICENSE',
     url='https://github.com/firebase/firebase-token-generator-python',


### PR DESCRIPTION
The zip_safe flag must be set to False, or otherwise the package will not install from an egg because it will not find README.md. This happens on python 2.7, probably on other versions too.

After this please release a new version 1.3 to pypi, to fix the installation problem. 
