### PR TITLE
Python 3 compatibility using six.string_types

### DIFF
--- a/firebase_token_generator.py
+++ b/firebase_token_generator.py
@@ -3,6 +3,7 @@ from base64 import urlsafe_b64encode
 import hashlib
 import hmac
 import sys
+import six
 try:
     import json
 except ImportError:
@@ -67,7 +68,7 @@ def create_token(secret, data, options=None):
         ValueError: if an invalid key is specified in options
 
     """
-    if not isinstance(secret, basestring):
+    if not isinstance(secret, six.string_types):
         raise ValueError("firebase_token_generator.create_token: secret must be a string.")
     if not options and not data:
         raise ValueError("firebase_token_generator.create_token: data is empty and no options are set.  This token will have no effect on Firebase.");
@@ -89,7 +90,7 @@ def _validate_data(data, is_admin_token):
     if data is not None and not isinstance(data, dict):
         raise ValueError("firebase_token_generator.create_token: data must be a dictionary")
     contains_uid = (data is not None and 'uid' in data)
-    if ((not contains_uid and not is_admin_token) or (contains_uid and not isinstance(data['uid'], basestring))):
+    if ((not contains_uid and not is_admin_token) or (contains_uid and not isinstance(data['uid'], six.string_types))):
         raise ValueError("firebase_token_generator.create_token: data must contain a \"uid\" key that must be a string.")
     if (contains_uid and (len(data['uid']) > 256)):
         raise ValueError("firebase_token_generator.create_token: data must contain a \"uid\" key that must not be longer than 256 bytes.")

--- a/firebase_token_generator_test.py
+++ b/firebase_token_generator_test.py
@@ -1,11 +1,12 @@
 from firebase_token_generator import create_token
 import unittest
+import six
 
 class TestTokenGenerator(unittest.TestCase):
 
     def test_smoke_test(self):
         token = create_token("barfoo", {"uid": "foo"})
-        self.assertIsInstance(token, basestring)
+        self.assertIsInstance(token, six.string_types)
 
     def test_malformed_key(self):
         with self.assertRaises(ValueError):
@@ -22,7 +23,7 @@ class TestTokenGenerator(unittest.TestCase):
     def test_uid_max_length(self):
         #length:                                        10        20        30        40        50        60        70        80        90       100       110       120       130       140       150       160       170       180       190       200       210       220       230       240       250   256
         token = create_token("barfoo", {"uid": "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456"})
-        self.assertIsInstance(token, basestring)
+        self.assertIsInstance(token, six.string_types)
 
     def test_uid_too_long(self):
         with self.assertRaises(ValueError):
@@ -31,7 +32,7 @@ class TestTokenGenerator(unittest.TestCase):
 
     def test_uid_min_length(self):
         token = create_token("barfoo", {"uid": ""})
-        self.assertIsInstance(token, basestring)
+        self.assertIsInstance(token, six.string_types)
 
     def test_token_too_long(self):
         with self.assertRaises(RuntimeError):
@@ -39,11 +40,11 @@ class TestTokenGenerator(unittest.TestCase):
 
     def test_no_uid_with_admin(self):
         token = create_token("barfoo", None, {"admin": True})
-        self.assertIsInstance(token, basestring)
+        self.assertIsInstance(token, six.string_types)
         token = create_token("barfoo", {}, {"admin": True})
-        self.assertIsInstance(token, basestring)
+        self.assertIsInstance(token, six.string_types)
         token = create_token("barfoo", {"foo": "bar"}, {"admin": True})
-        self.assertIsInstance(token, basestring)
+        self.assertIsInstance(token, six.string_types)
 
     def test_invalid_uid_with_admin(self):
         with self.assertRaises(ValueError):

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     license='LICENSE',
     url='https://github.com/firebase/firebase-token-generator-python',
     description='A utility to generate signed Firebase Authentication Tokens',
-    long_description=read('README')
+    long_description=read('README'),
+    install_requires=['six']
 )


### PR DESCRIPTION
using basestring breaks the library on Python3, this fixes the issue if you are ok with using six 
